### PR TITLE
Remove rm(1) call to undefined variable

### DIFF
--- a/enhancements/grommunio-spam-run.sh
+++ b/enhancements/grommunio-spam-run.sh
@@ -67,7 +67,6 @@ if ${MYSQL_CMD[@]}<<<"exit"&>/dev/null; then
         /usr/sbin/gromox-mbop -u "${USERNAME}" delmsg -f 0x17 "${MESSAGEID}" | systemd-cat -t grommunio-spam-run
       fi
     done
-    rm -f "${SPAMLIST}"
   done
 else
   echo "MySQL-Connection couldn't be established, please check your configuration." | systemd-cat -t grommunio-spam-run -p err


### PR DESCRIPTION
`rm -f "${SPAMLIST}"` doesn't make sense, because `${SPAMLIST}` is undefined