### PR TITLE
Fix Bash/SQLite query quoting

### DIFF
--- a/enhancements/grommunio-ham-run.sh
+++ b/enhancements/grommunio-ham-run.sh
@@ -34,7 +34,7 @@ SELECT m.message_id,
   ON m.parent_fid = f.folder_id
   JOIN folder_properties fp
   ON fp.folder_id = f.folder_id
-  WHERE fp.propval LIKE ''${HAMRUN_FOLDER}''
+  WHERE fp.propval LIKE '"${HAMRUN_FOLDER}"'
 -- DON'T LOOK INTO SUBDIRECTORIES
     AND f.parent_id = 9
   """


### PR DESCRIPTION
Using `''${HAMRUN_FOLDER}''` fails at least in Bash 5.1 (CentOS/RHEL/Rocky Linux 9) all the time. From my point of understanding the intention in the script is to have SQLite query quoting but still interpolate the `${HAMRUN_FOLDER}` variable.