### PR TITLE
Remove Python-like triple quotes in Bash script

### DIFF
--- a/enhancements/grommunio-spam-run.sh
+++ b/enhancements/grommunio-spam-run.sh
@@ -29,7 +29,7 @@ fi
 if [ -z ${SPAMRUN_DAYS+x} ]; then
   SQLITE_QUERY='select message_id,mid_string from messages where parent_fid=0x17;'
 else
-  SQLITE_QUERY="""
+  SQLITE_QUERY="
   SELECT m.message_id,m.mid_string
   FROM messages m
   INNER JOIN message_properties mp1
@@ -37,7 +37,7 @@ else
   AND mp1.proptag = 235274304
   AND (mp1.propval/10000000-11644473600) < unixepoch('now','-$SPAMRUN_DAYS days')
   WHERE m.parent_fid = 0x17;
-  """
+  "
 fi
 DO_DEL="${SPAMRUN_DELETE:-"false"}"
 # add "-d" to delete junk emails after they have been learned


### PR DESCRIPTION
Bash does not support triple quotes, that's Python-like style. Practically it's `""` `"string"` `""`, so the concatenation of an empty string with the actual SQL query followed by an empty string. I suggest to remove it to improve the readability of a pure Bash script.